### PR TITLE
Kops Manifest for Chaos Cluster Creation

### DIFF
--- a/kops/cloud-platform-chaos.yaml
+++ b/kops/cloud-platform-chaos.yaml
@@ -38,9 +38,9 @@ spec:
     legacy: false
   kubeAPIServer:
     oidcClientID: WAgw4FygIHs1Vny6whAjfnem6BiUr4qv
-    oidcIssuerURL: https://login.apps.test-2.cloud-platform.dsd.io/ui
+    oidcIssuerURL: https://moj-cloud-platform-test-2.eu.auth0.com
     oidcUsernameClaim: nickname
-    oidcGroupsClaim: https://cloud-platform.dsd.io/groups
+    oidcGroupsClaim: https://test-2.cloud-platform.dsd.io/groups
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.10.3

--- a/kops/cloud-platform-chaos.yaml
+++ b/kops/cloud-platform-chaos.yaml
@@ -1,0 +1,107 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  additionalPolicies:
+    node: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "route53:ChangeResourceRecordSets"
+          ],
+          "Resource": [
+            "arn:aws:route53:::hostedzone/Z2ICAAX9I27W2Q"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "route53:ListHostedZones",
+            "route53:ListResourceRecordSets"
+          ],
+          "Resource": [
+            "*"
+          ]
+        }
+      ]
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubeAPIServer:
+    oidcClientID: WAgw4FygIHs1Vny6whAjfnem6BiUr4qv
+    oidcIssuerURL: https://login.apps.test-2.cloud-platform.dsd.io/ui
+    oidcUsernameClaim: nickname
+    oidcGroupsClaim: https://cloud-platform.dsd.io/groups
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.10.3
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1a
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1b
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1c
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: nodes
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 3
+  minSize: 3
+  role: Node


### PR DESCRIPTION
**WHAT**
This PR contains a kops manifest to be used in a pipeline to create a cluster for Chaos Engineering. We have decided to keep the instance size as minimal as possible to keep costs down. 

**WHY**
This will enable the Cloud Platform team to create a Chaos cluster manually. 